### PR TITLE
Convert PoC bash scripts to a ruby tool to generate Anki cards

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,3 +1,3 @@
 # Merriam-Webster dictionary API key
 # see: https://dictionaryapi.com/
-MW_API_KEY="TOP SECRET API KEY"
+DICTIONARY_API_KEY="TOP SECRET API KEY"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+AllCops:
+  NewCops: enable
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: either

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@
 source 'https://rubygems.org'
 
 gem 'dotenv'
+gem 'http'
 gem 'rubocop', '~> 1.39', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@
 source 'https://rubygems.org'
 
 gem 'dotenv'
+gem 'down', '~> 5.0'
 gem 'http'
 gem 'rubocop', '~> 1.39', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,8 @@ GEM
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.8.1)
+    down (5.3.1)
+      addressable (~> 2.8)
     ffi (1.15.5)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
@@ -55,6 +57,7 @@ PLATFORMS
 
 DEPENDENCIES
   dotenv
+  down (~> 5.0)
   http
   rubocop (~> 1.39)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,34 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.8.1)
+    ffi (1.15.5)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
+    http (5.1.0)
+      addressable (~> 2.8)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      llhttp-ffi (~> 0.4.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
     json (2.6.3)
+    llhttp-ffi (0.4.0)
+      ffi-compiler (~> 1.0)
+      rake (~> 13.0)
     parallel (1.22.1)
     parser (3.1.3.0)
       ast (~> 2.4.1)
+    public_suffix (5.0.1)
     rainbow (3.1.1)
+    rake (13.0.6)
     regexp_parser (2.6.1)
     rexml (3.2.5)
     rubocop (1.39.0)
@@ -23,6 +44,9 @@ GEM
     rubocop-ast (1.24.0)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     unicode-display_width (2.3.0)
 
 PLATFORMS
@@ -31,6 +55,7 @@ PLATFORMS
 
 DEPENDENCIES
   dotenv
+  http
   rubocop (~> 1.39)
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -1,22 +1,39 @@
 # spelling-bee training tools
 
-This will probably just generate Anki cards with pronunciations and definitions on the front, with 
-the spelled word on the back.
+## Introduction
 
-### rough TODO
+Generate [Anki](https://apps.ankiweb.net/) card decks for studying for the 2022 Scripps Spelling Bee.
 
- - [x] find a way to get pronunciations
- - [x] find an API for word definition lookups
- - [x] look up word definitions
- - [x] find a ruby lib to generate anki cards (https://github.com/rkachowski/anki-rb)
- - [x] upgrade dictionary API key to use the highest level dictionary available from MW (currently too low level for all words)
- - [ ] roll a ruby script that automates populating data and cards
-   - [x] sketch script
-   - [x] add .env support for MW API key
-   - [ ] bring in rubocop
-   - [ ] make initial test suite at least be a rubocop run
-   - [ ] for each word pull definitions, handle errors properly (i.e., detect them, also make an exceptions log); be idempotent
-     - [ ] also, probably use "shortdef" fields in JSON results, as these are cleaner
-   - [ ] ... pull pronunciations (similarly, with the error handling), also be idempotent
-   - [ ] generate Anki cards with audio file linkage, definitions (front) and correct spelling (back)
-   - [ ] handle alternate spellings (probably an alternates hash in a JSON doc or something; add alternates to card backs
+The spelling bee word lists are broken out into "bee" levels ("1 bee", "2 bees", "3 bees").
+For each level there is a "school study list" (i.e., basic words), and a "champion study list"
+(i.e., words that winners of a local spelling bee competition should study for the next round(s)).
+
+We have our school word lists in `words/` as `1.txt`, `2.txt`, and `3.txt` for the
+respective "bee" levels. Similarly, the "champion" words are in `words` as `1-champ.txt`, etc.
+
+## Cards
+
+The generated Anki cards will each have:
+
+ - **front**:
+   - an audio file pronouncing the word
+   - a definition (or short list of main definitions) for the word
+ - **back**:
+   - the spelling of the word, with alternative spellings
+
+### Data sources
+
+ - Our school emailed us a PDF of this year's words (as we have a bee winner in our midst)
+ - We will be using the Merriam-Webster online Collegiate Dictionary API, at https://dictionaryapi.com/ to look up definitions.
+ - We are downloading pronunciation `.mp3` files from Google; if this doesn't work out we may try M-W as well, or look for yet another source.
+
+## Building your own cards
+
+ - Clone this repo.
+ - Go to https://dictionaryapi.com/ and get an API key.
+ - `cp .env-example .env` and edit `.env` to put your API key in place
+ - Run the generator (which will download any missing data first):
+
+``` shell
+bundle exec script/build_cards.rb -f words/1-champ.txt -o 1-champ.apkg
+```

--- a/lib/definition_lookup_service.rb
+++ b/lib/definition_lookup_service.rb
@@ -19,7 +19,7 @@ class DefinitionLookupService
   end
 
   def definitions_for(word)
-    response = HTTP.get(url + CGI.escape(word) + "?key=#{key}")
+    response = HTTP.get(url + CGI.escape(word), params => { key: key })
     return false unless response.status.success?
 
     parse_response(response.body)

--- a/lib/definition_lookup_service.rb
+++ b/lib/definition_lookup_service.rb
@@ -10,7 +10,8 @@ class DefinitionLookupService
 
   def initialize
     @url = 'https://dictionaryapi.com/api/v3/references/collegiate/json/'
-    @key = ENV['DICTIONARY_API_KEY']
+    @key = ENV.fetch('DICTIONARY_API_KEY')
+    raise 'Please set the DICTIONARY_API_KEY environment variable.' unless key
   end
 
   def parse_response(json)

--- a/lib/definition_lookup_service.rb
+++ b/lib/definition_lookup_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'cgi'
+require 'dotenv/load'
+require 'http'
+
+# Wrap M-W Dictionary API, providing a simple interface for fetching word definitions
+class DefinitionLookupService
+  attr_reader :key, :url
+
+  def initialize
+    @url = 'https://dictionaryapi.com/api/v3/references/collegiate/json/'
+    @key = ENV['DICTIONARY_API_KEY']
+  end
+
+  def parse_response(json)
+    data = JSON.parse(json)
+    data.first['shortdef']
+  end
+
+  def definitions_for(word)
+    response = HTTP.get(url + CGI.escape(word) + "?key=#{key}")
+    return false unless response.status.success?
+
+    parse_response(response.body)
+  end
+end

--- a/lib/pronunciation_lookup_service.rb
+++ b/lib/pronunciation_lookup_service.rb
@@ -16,8 +16,8 @@ class PronunciationLookupService
   def pronunciation_audio_for(word)
     full_url = url.gsub('%%%WORD%%%', CGI.escape(word))
     Down.download(full_url)
-  rescue Down::Error => err
-    STDERR.puts "Failed to download pronunciation for #{word}: #{err}"
+  rescue Down::Error => e
+    warn "Failed to download pronunciation for #{word}: #{e}"
     false
   end
 end

--- a/lib/pronunciation_lookup_service.rb
+++ b/lib/pronunciation_lookup_service.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'cgi'
+require 'dotenv/load'
+require 'down'
+require 'http'
+
+# Wrap Google static pronuncation files endpoint, providing a simple interface for fetching word pronunciations
+class PronunciationLookupService
+  attr_reader :url
+
+  def initialize
+    @url = 'https://ssl.gstatic.com/dictionary/static/sounds/oxford/%%%WORD%%%--_us_1.mp3'
+  end
+
+  def pronunciation_audio_for(word)
+    full_url = url.gsub('%%%WORD%%%', CGI.escape(word))
+    Down.download(full_url)
+  rescue Down::Error => err
+    STDERR.puts "Failed to download pronunciation for #{word}: #{err}"
+    false
+  end
+end

--- a/lib/word_collector.rb
+++ b/lib/word_collector.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 # Manage collection and storage of words, definitions, and pronunciations
 class WordCollector
   attr_reader :words
@@ -9,13 +8,25 @@ class WordCollector
     @words = {}
   end
 
+  def audio_base_path
+    File.join(File.dirname(__FILE__), '..', 'audio')
+  end
+
+  def audio_path(word)
+    File.join(audio_base_path, "#{word.downcase}.mp3")
+  end
+
   def definition_for?(word)
     words[word] && words[word][:definition]
   end
 
   def pronunciation_for?(word)
+    # TODO: check for the existence of the audio file; load on request
     words[word] && words[word][:pronunciation]
   end
+
+  # TODO: probably need a pronunciation(word) method that also loads the audio file
+  # TODO: probably need a definitions(word) method that also loads the definition data
 
   def add_word(word)
     words[word] ||= {}
@@ -25,8 +36,15 @@ class WordCollector
     words[word][:definition] = definition
   end
 
-  # TODO: ensure we add something representing the pronunciation audio
-  def add_pronunciation(word, pronunciation)
-    words[word][:pronunciation] = pronunciation
+  def add_pronunciation(word, tempfile)
+    words[word][:pronunciation] = tempfile
+    store_pronunciation(word, tempfile)
+  end
+
+  def store_pronunciation(word, tempfile)
+    tempfile.close
+    FileUtils.cp(tempfile.path, audio_path(word))
+  ensure
+    tempfile.unlink
   end
 end

--- a/lib/word_collector.rb
+++ b/lib/word_collector.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+
+# Manage collection and storage of words, definitions, and pronunciations
+class WordCollector
+  attr_reader :words
+
+  def initialize
+    @words = {}
+  end
+
+  def definition_for?(word)
+    words[word] && words[word][:definition]
+  end
+
+  def pronunciation_for?(word)
+    words[word] && words[word][:pronunciation]
+  end
+
+  def add_word(word)
+    words[word] ||= {}
+  end
+
+  def add_definition(word, definition)
+    words[word][:definition] = definition
+  end
+
+  # TODO: ensure we add something representing the pronunciation audio
+  def add_pronunciation(word, pronunciation)
+    words[word][:pronunciation] = pronunciation
+  end
+end

--- a/script/build_cards.rb
+++ b/script/build_cards.rb
@@ -1,6 +1,30 @@
 # frozen_string_literal: true
 
 require 'dotenv/load'
+require 'http'
+require 'cgi'
+
+# Wrap M-W Dictionary API, providing a simple interface for fetching word definitions
+class DefinitionLookupService
+  attr_reader :key, :url
+
+  def initialize
+    @url = 'https://dictionaryapi.com/api/v3/references/collegiate/json/'
+    @key = ENV['DICTIONARY_API_KEY']
+  end
+
+  def parse_response(json)
+    JSON.parse(json)
+    # TODO: extract the definition(s) from the response
+  end
+
+  def definitions_for(word)
+    response = HTTP.get(url + CGI.escape(word) + "?key=#{key}")
+    return false unless response.status.success?
+
+    parse_response(response.body)
+  end
+end
 
 # read in all spellings words from a file
 def gather_words(input_file)
@@ -9,6 +33,12 @@ def gather_words(input_file)
     words << line.chomp
   end
   words
+end
+
+# Request the dictionary definition(s) for a word
+def definitions_for(word)
+  # TODO: check if the word has a stored definition, returning that instead
+  DefinitionLookupService.new.definitions_for(word)
 end
 
 def fetch_alternate_spellings

--- a/script/build_cards.rb
+++ b/script/build_cards.rb
@@ -40,6 +40,7 @@ def fetch_definitions(collector, words)
   # for each word that does not have a stored definition, fetch and store
   words.each do |word|
     definitions_for(collector, word)
+    break if word != 'ensdfd' # TODO: remove me
   end
 end
 
@@ -47,6 +48,7 @@ def fetch_pronunciations(collector, words)
   # for each word that does not have a stored pronunciation, fetch and store
   words.each do |word|
     pronunciation_for(collector, word)
+    break if word != 'ensdfd' # TODO: remove me
   end
 end
 
@@ -74,13 +76,19 @@ end
 if $PROGRAM_NAME == __FILE__
   # get command-line options
   options = {}
-  OptionParser.new do |opts|
+  parser = OptionParser.new do |opts|
     opts.banner = 'Usage: build-cards.rb [options]'
 
     opts.on('-f', '--file', 'Spellings words input file') do |f|
       options[:file] = f
     end
   end
+
+  # parse the command-line options
+  parser.parse!
+
+  puts options.inspect
+  raise 'Please specify an input file.' unless options[:file]
 
   # get the input file
   input_file = options[:file]

--- a/script/build_cards.rb
+++ b/script/build_cards.rb
@@ -1,7 +1,26 @@
 # frozen_string_literal: true
 
+require 'fileutils'
+require 'optparse'
 require_relative '../lib/definition_lookup_service'
 require_relative '../lib/pronunciation_lookup_service'
+
+# TODO: make this a class
+
+def audio_base_path
+  File.join(File.dirname(__FILE__), '..', 'audio')
+end
+
+def audio_path(word)
+  File.join(audio_base_path, "#{word.downcase}.mp3")
+end
+
+def store_pronunciation(word, tempfile)
+  tempfile.close
+  FileUtils.cp(tempfile.path, audio_path(word))
+ensure
+  tempfile.unlink
+end
 
 # read in all spellings words from a file
 def gather_words(input_file)
@@ -24,11 +43,11 @@ def fetch_definitions(words)
   # TODO: for each word that does not have a stored definition, fetch and store
 end
 
-def fetch_pronunciations(words)
+def fetch_pronunciations(word)
   # TODO: check if the word has a stored pronunciation, returning that instead
   tempfile = PronunciationLookupService.new.pronunciation_audio_for(word)
-  # TODO: now store this audio file
   # TODO: if false, do error logging
+  store_pronunciation(word, tempfile)
 end
 
 def fetch_alternate_spellings

--- a/script/build_cards.rb
+++ b/script/build_cards.rb
@@ -1,30 +1,6 @@
 # frozen_string_literal: true
 
-require 'dotenv/load'
-require 'http'
-require 'cgi'
-
-# Wrap M-W Dictionary API, providing a simple interface for fetching word definitions
-class DefinitionLookupService
-  attr_reader :key, :url
-
-  def initialize
-    @url = 'https://dictionaryapi.com/api/v3/references/collegiate/json/'
-    @key = ENV['DICTIONARY_API_KEY']
-  end
-
-  def parse_response(json)
-    JSON.parse(json)
-    # TODO: extract the definition(s) from the response
-  end
-
-  def definitions_for(word)
-    response = HTTP.get(url + CGI.escape(word) + "?key=#{key}")
-    return false unless response.status.success?
-
-    parse_response(response.body)
-  end
-end
+require_relative '../lib/definition_lookup_service'
 
 # read in all spellings words from a file
 def gather_words(input_file)

--- a/script/build_cards.rb
+++ b/script/build_cards.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../lib/definition_lookup_service'
+require_relative '../lib/pronunciation_lookup_service'
 
 # read in all spellings words from a file
 def gather_words(input_file)
@@ -15,13 +16,8 @@ end
 def definitions_for(word)
   # TODO: check if the word has a stored definition, returning that instead
   DefinitionLookupService.new.definitions_for(word)
-end
-
-def fetch_alternate_spellings
-  # load JSON file of alternative spellings
-  # TODO: make a reasonable location for this file
-  # TODO: bring alternative spellings into the hash
-  # JSON.parse(File.read("path/alternative-spellings.json"))
+  # TODO: store the definition(s) in the hash
+  # TODO: if false, do error logging
 end
 
 def fetch_definitions(words)
@@ -29,7 +25,17 @@ def fetch_definitions(words)
 end
 
 def fetch_pronunciations(words)
-  # TODO: for each word that does not have a stored pronunciation, fetch and store
+  # TODO: check if the word has a stored pronunciation, returning that instead
+  tempfile = PronunciationLookupService.new.pronunciation_audio_for(word)
+  # TODO: now store this audio file
+  # TODO: if false, do error logging
+end
+
+def fetch_alternate_spellings
+  # load JSON file of alternative spellings
+  # TODO: make a reasonable location for this file
+  # TODO: bring alternative spellings into the hash
+  # JSON.parse(File.read("path/alternative-spellings.json"))
 end
 
 def build_cards(words)

--- a/script/build_cards.rb
+++ b/script/build_cards.rb
@@ -4,8 +4,7 @@ require 'fileutils'
 require 'optparse'
 require_relative '../lib/definition_lookup_service'
 require_relative '../lib/pronunciation_lookup_service'
-
-# TODO: make this a class
+require_relative '../lib/word_collector'
 
 def audio_base_path
   File.join(File.dirname(__FILE__), '..', 'audio')
@@ -29,36 +28,6 @@ def gather_words(input_file)
     words << line.chomp
   end
   words
-end
-
-# Manage collection and storage of words, definitions, and pronunciations
-class WordCollector
-  attr_reader :words
-
-  def initialize
-    @words = {}
-  end
-
-  def definition_for?(word)
-    words[word] && words[word][:definition]
-  end
-
-  def pronunciation_for?(word)
-    words[word] && words[word][:pronunciation]
-  end
-
-  def add_word(word)
-    words[word] ||= {}
-  end
-
-  def add_definition(word, definition)
-    words[word][:definition] = definition
-  end
-
-  # TODO: ensure we add something representing the pronunciation audio
-  def add_pronunciation(word, pronunciation)
-    words[word][:pronunciation] = pronunciation
-  end
 end
 
 # Request the dictionary definition(s) for a word
@@ -109,6 +78,7 @@ end
 
 def generate_cards(input_file)
   words = gather_words(input_file)
+  collector = WordCollector.new
   fetch_alternate_spellings(collector, words)
   fetch_definitions(collector, words)
   fetch_pronunciations(collector, words)

--- a/script/build_cards.rb
+++ b/script/build_cards.rb
@@ -6,21 +6,6 @@ require_relative '../lib/definition_lookup_service'
 require_relative '../lib/pronunciation_lookup_service'
 require_relative '../lib/word_collector'
 
-def audio_base_path
-  File.join(File.dirname(__FILE__), '..', 'audio')
-end
-
-def audio_path(word)
-  File.join(audio_base_path, "#{word.downcase}.mp3")
-end
-
-def store_pronunciation(word, tempfile)
-  tempfile.close
-  FileUtils.cp(tempfile.path, audio_path(word))
-ensure
-  tempfile.unlink
-end
-
 # read in all spellings words from a file
 def gather_words(input_file)
   words = []

--- a/script/lookup.sh
+++ b/script/lookup.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-
-sed 's,^\(.*\)$,curl -s -H "Accept: application/json" -H "Content-Type: application/json" -o - "https://www.dictionaryapi.com/api/v3/references/sd3/json/\1?key='${API_KEY}'",' | \
-	 sh -s -x | \
-	 jq '.[].def[].sseq[][][1].dt[0][1]' | \
-	 sed 's,{[^\{]*},,g' | \
-	 grep '[a-zA-Z]' | \
-	 sed 's,^,    ,'


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/6259/206304560-e0d5f974-dbe4-4eaf-a31d-83741c8d081c.png)


**the work**

 - [x] update README
 - [x] bring TODO list into this PR description
 - [ ] roll a ruby script that automates populating data and cards
   - [x] sketch script
   - [x] add .env support for MW API key
   - [x] bring in rubocop
   - [x] make initial test suite at least be a rubocop run
   - [ ] word definitions
     - [x] fetch a definition via the API
     - [x] extract `shortdef` list
     - [ ] do not fetch if already stored
     - [ ] otherwise, store the definition
     - [ ] on error
       - [x] return false to caller
       - [ ] log to exceptions file
       - [ ] do not store the definition
   - [ ] pronunciations
     - [x] fetch a pronunciation
     - [x] store in an mp3 file
     - [ ] on error
       - [x] return false to caller
       - [x] do not update storage
       - [ ] log to exceptions file
   - [ ] generate Anki cards with audio file linkage, definitions (front) and correct spelling (back)
   - [ ] handle alternate spellings (probably an alternates hash in a JSON doc or something; add alternates to card backs
